### PR TITLE
Adding the ability to declare a `const` or a `var` as a parameter in the `components` section

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -90,11 +90,11 @@ func ControllerFunc() {
 }
 ```
 
-===== Schema Object
+===== Object Schema
 
 Annotate a struct with a `gopenapi:objectSchema`.
 
-The generated ObjectSchema element will be appended to the `components.schemas` property fo the specification.
+The generated ObjectSchema element will be appended to the `components.schemas` property of the specification.
 
 ```go
 //gopenapi:objectSchema
@@ -117,3 +117,23 @@ type AliasedModel struct {
 }
 
 ```
+
+===== Parameter
+
+Annotate a `const` or a `var` with a `gopenapi:parameter`.
+
+The annotated field will be appended to the `components.parameters` property of the specification.
+
+```go
+/*
+gopenapi:parameter
+in: path
+required: true
+content:
+  text/plain:
+    example: 30
+*/
+const Limit = "limit"
+```
+
+The name of the field (`Limit`) will be the parameter identifier and the value of the field (`limit`) will be the name of the parameter.

--- a/interpret/_test_files/func_with_parameter.go
+++ b/interpret/_test_files/func_with_parameter.go
@@ -1,0 +1,23 @@
+// +build testResource
+
+package _test_files
+
+/*
+gopenapi:parameter
+in: path
+required: true
+content:
+  text/plain:
+    example: some text
+*/
+const ConstParamName = "constParamName"
+
+/*
+gopenapi:parameter
+in: query
+required: true
+content:
+  text/plain:
+    example: some text
+*/
+var VarParamName = "varParamName"

--- a/interpret/interpret_test.go
+++ b/interpret/interpret_test.go
@@ -41,6 +41,7 @@ func TestASTInterpreter_Path(t *testing.T) {
 	a.Equal("The default response of \"ping\"", root.Paths["/ping"].Get.Responses["200"].Description)
 	a.Equal("pong", root.Paths["/ping"].Get.Responses["200"].Content["text/plain"].Example)
 }
+
 func TestASTInterpreter_Models(t *testing.T) {
 	a := assert.New(t)
 
@@ -80,4 +81,24 @@ func TestASTInterpreter_Models(t *testing.T) {
 	a.Equal("object", aliasedSub.Type)
 	a.Equal("string", aliasedSub.Properties["timeField"].Type)
 	a.Equal("date-time", aliasedSub.Properties["timeField"].Format)
+}
+
+func TestASTInterpreter_Parameter(t *testing.T) {
+	a := assert.New(t)
+
+	file, openError := os.Open("./_test_files/func_with_parameter.go")
+	a.NoError(openError)
+
+	root := models.Root{}
+	interpreter := &interpret.ASTInterpreter{}
+	a.NoError(interpreter.InterpretFile(file, &root))
+	parameter := root.Components.Parameters["ConstParamName"]
+	a.Equal("constParamName", parameter.Name)
+	a.Equal("path", parameter.In)
+	a.Equal("some text", parameter.Content["text/plain"].Example)
+
+	parameter = root.Components.Parameters["VarParamName"]
+	a.Equal("varParamName", parameter.Name)
+	a.Equal("query", parameter.In)
+	a.Equal("some text", parameter.Content["text/plain"].Example)
 }


### PR DESCRIPTION
This change lets us annotate `const` and `var` fields using the `gopenapi:parameter` keyword. The parameters will then be added to `components` where the name of the field is the parameter identifier and the value of the field is the parameter name